### PR TITLE
Show the arcus stats belongs to the given serviceCode and server.

### DIFF
--- a/view/modules/controllers.js
+++ b/view/modules/controllers.js
@@ -229,6 +229,9 @@ angular.module("controllers",[])
 	  					if (arcusport && arcusport.length != 0 && arcusport.indexOf(p) == -1) {
 	  						return;
 	  					}
+	  					if ($scope.ports && !$scope.ports.includes(p)) {
+	  						return;
+	  					}
 	  				}
 
 	  				var subtab = { key: subk, title: subk, active: subk == psubtab };
@@ -365,8 +368,11 @@ angular.module("controllers",[])
       Hubble.setShared("server", $scope.serverList[0]);
       Hubble.setShared("arcusport", $scope.arcusPort);
 
-      //$scope.initTabs($scope.hubble, $scope.server, {excludes: 'arcus_prefixes', grouped: true});
-      $scope.initTabs($scope.hubble, $scope.server, $routeParams.tab, $routeParams.subtab, {grouped: true});
-    });
+      Hubble.getPorts($scope.serviceCode, $scope.server, function(ports) {
+      	$scope.ports = ports;
+      	//$scope.initTabs($scope.hubble, $scope.server, {excludes: 'arcus_prefixes', grouped: true});
+      	$scope.initTabs($scope.hubble, $scope.server, $routeParams.tab, $routeParams.subtab, {grouped: true});
+      });
+  });
   }])
 ;

--- a/view/modules/directives.js
+++ b/view/modules/directives.js
@@ -60,6 +60,9 @@ angular.module("directives",[])
           if (arcusport && arcusport.length != 0 && arcusport.indexOf(p) == -1) {
             return;
           }
+          if (!scope.ports.includes(p)) {
+            return;
+          }
         }
         aggregated.push([k, key].join("/"));
       });
@@ -85,6 +88,9 @@ angular.module("directives",[])
             // FIXME 콘솔리데이션 처리...
             var p = k.split("-")[1];
             if (arcusport && arcusport.length != 0 && arcusport.indexOf(p) == -1) {
+              return;
+            }
+            if (!scope.ports.includes(p)) {
               return;
             }
           }

--- a/view/modules/services.js
+++ b/view/modules/services.js
@@ -158,6 +158,27 @@ angular.module("services", [])
         $http.get(partial, { cache: $templateCache }).then(function(result) {
           //console.log(partial + " loaded and cached");
         })
+      },
+      getPorts: function(serviceCode, server, callback) {
+        var config = { cache: true };
+        var url = ["http://", HUBBLE_ADDRESS, "/api/v1/cluster_by_ip", "?callback=JSON_CALLBACK"].join("");
+        $http.jsonp(url, config).success(function(data, status) {
+          var result = [];
+          for (var k in data) {
+            var host = k.split(":")[0];
+            if (host == server) {
+              if (data[k].includes(serviceCode)) {
+                var port = k.split(":")[1];
+                if (port) {
+                  result.push(port);
+                }
+              }
+            }
+          }
+          callback(result);
+        }).error(function(data, status) {
+          console.log(data, status);
+        });
       }
     };
   }])


### PR DESCRIPTION
Related issue : https://github.com/naver/kaist-oss-course/issues/60

getPorts 에 serviceCode, server 를 주면 해당 서버에서 특정 serviceCode 에 속하는 포트 넘버 Array 를 리턴합니다. arcus 관련 directive 에서 해당 ports 에 속하는지 필터하고, initTab 할 때도 같이 필터링 합니다.
