### PR TITLE
Dockerize collectd server and arcus-memcached with collectd.

### DIFF
--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -1,0 +1,18 @@
+FROM arcus/arcus-memcached:latest
+
+ENV COLLECTD_LISTENER_5S_PORT 25828
+ENV COLLECTD_LISTENER_1M_PORT 25829
+
+RUN apk add --no-cache collectd collectd-network collectd-rrdtool collectd-python rrdtool-dev
+
+COPY collectd.conf /etc/collectd/
+COPY types.db /usr/share/collectd/types.db
+
+RUN mkdir -p /usr/lib/collectd/python
+COPY arcus_stat.py /usr/lib/collectd/python/
+
+COPY client-collectd.conf.d /etc/collectd/collectd.conf.d
+COPY client-entrypoint.sh /
+
+ENTRYPOINT ["./client-entrypoint.sh"]
+CMD ["memcached", "-u", "memcached", "-p", "11211", "-E", "/usr/local/lib/default_engine.so"]

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -1,0 +1,11 @@
+FROM alpine:3.4
+
+RUN apk add --no-cache collectd collectd-network collectd-rrdtool rrdtool-dev
+RUN mkdir -p /var/lib/collectd/rrd
+
+COPY collectd.conf /etc/collectd/
+COPY types.db /usr/share/collectd/types.db
+
+COPY server-collectd.conf.d /etc/collectd/collectd.conf.d
+
+CMD ["collectd", "-f"]

--- a/docker/arcus_stat.py
+++ b/docker/arcus_stat.py
@@ -1,0 +1,313 @@
+import re
+import os
+import time
+import socket
+import collectd
+import traceback
+
+MEMCACHED_HOST = 'localhost'
+MEMCACHED_PORTS = []
+COLLECTION_MODE = 'stat'
+
+TYPE_COMMENTS_RE = '^[#\\s]'
+TYPE_CUT_RE = '^([^\s]+)\s+(.*)'
+
+TYPES_DB = {}
+
+TYPES_CONV = {
+  'kv_get' : 'get',
+  'kv_hit' : 'hit',
+  'kv_set' : 'set',
+  'kv_del' : 'del',
+  'lop_create' : 'lcs',
+  'lop_insert' : 'lis',
+  'lop_insert_hit' : 'lih',
+  'lop_delete' : 'lds',
+  'lop_delete_hit' : 'ldh',
+  'lop_get' : 'lgs',
+  'lop_get_hit' : 'lgh',
+  'sop_create' : 'scs',
+  'sop_insert' : 'sis',
+  'sop_insert_hit' : 'sih',
+  'sop_delete' : 'sds',
+  'sop_delete_hit' : 'sdh',
+  'sop_get' : 'sgs',
+  'sop_get_hit' : 'sgh',
+  'sop_exist' : 'ses',
+  'sop_exist_hit' : 'seh',
+  'bop_create' : 'bcs',
+  'bop_insert' : 'bis',
+  'bop_insert_hit' : 'bih',
+  'bop_update' : 'bus',
+  'bop_update_hit' : 'buh',
+  'bop_incr' : 'bps',
+  'bop_incr_hit' : 'bph',
+  'bop_decr' : 'bms',
+  'bop_decr_hit' : 'bmh',
+  'bop_delete' : 'bds',
+  'bop_delete_hit' : 'bdh',
+  'bop_get' : 'bgs',
+  'bop_get_hit' : 'bgh',
+  'bop_count' : 'bns',
+  'bop_count_hit' : 'bnh',
+  'getattr' : 'gas',
+  'setattr' : 'sas'
+}
+
+QOS_OPS = {
+  'qos_kv_set' : 'set arcus:qos-kv 0 3 4\r\nDATA\r\n',
+  'qos_kv_get' : 'get arcus:qos-kv\r\n',
+  'qos_lop_insert' : 'lop insert arcus:qos-lop 0 4 create 0 3 10\r\nDATA\r\n',
+  'qos_lop_get' : 'lop get arcus:qos-lop 0..10\r\n',
+  'qos_lop_delete' : 'lop delete arcus:qos-lop 0..10 drop\r\n',
+  'qos_sop_insert' : 'sop insert arcus:qos-sop 4 create 0 3 10\r\nDATA\r\n',
+  'qos_sop_exist' : 'sop exist arcus:qos-sop 4\r\nDATA\r\n',
+  'qos_sop_delete' : 'sop delete arcus:qos-sop 4 drop\r\nDATA\r\n',
+  'qos_bop_insert' : 'bop insert arcus:qos-bop 1 4 create 0 3 10\r\nDATA\r\n',
+  'qos_bop_get' : 'bop get arcus:qos-bop 1..10\r\n',
+  'qos_bop_delete' : 'bop delete arcus:qos-bop 1..10 10 drop\r\n'
+}
+
+QOS_RES = {
+  'qos_kv_set' : 'STORED\r\n',
+  'qos_kv_get' : 'END\r\n',
+  'qos_lop_insert' : 'CREATED_STORED\r\n',
+  'qos_lop_get' : 'END\r\n',
+  'qos_lop_delete' : 'DELETED_DROPPED\r\n',
+  'qos_sop_insert' : 'CREATED_STORED\r\n',
+  'qos_sop_exist' : 'EXIST\r\n',
+  'qos_sop_delete' : 'DELETED_DROPPED\r\n',
+  'qos_bop_insert' : 'CREATED_STORED\r\n',
+  'qos_bop_get' : 'END\r\n',
+  'qos_bop_delete' : 'DELETED_DROPPED\r\n'
+}
+
+def str_to_num(s):
+  try:
+    n = float(s)
+  except ValueError:
+    n = 0
+  return n
+
+def get_memcached_ports():
+  result = []
+  pids = [pid for pid in os.listdir('/proc') if pid.isdigit()]
+
+  for pid in pids:
+    try:
+      cmd = open(os.path.join('/proc', pid, 'cmdline'), 'r').read()
+      if 'memcached' in cmd and 'default_engine.so' in cmd:
+        port = re.findall('-p\x00([\d]+)', cmd)
+        if len(port) > 0:
+          result.append(int(port[0]))
+    except Exception, e:
+      continue
+
+  return result
+
+def get_type_instances(dbfile):
+  result = {}
+  types = []
+  types_file = file(dbfile, 'r')
+  for line in types_file.readlines():
+    types.append(line.replace('\r\n', ''))
+  types_file.close()
+
+  for type in types:
+    if not re.search(TYPE_COMMENTS_RE, type):
+      typeobj = re.findall(TYPE_CUT_RE, type)[0]
+      typename = typeobj[0]
+      result[typename] = {}
+      result[typename]['dsnames'] = []
+      eachtype = typeobj[1].split(', ')
+      for each in eachtype:
+        # lop_get:COUNTER:0:U
+        props = each.split(':')
+
+        if typename.startswith('arcus_stats'):
+          # FIXME fix for rrdtool's dsname character limit(=19 chars)
+          props[0] = props[0].replace('ins', 'insert').replace('upd', 'update').replace('del', 'delete')
+        elif typename.startswith('arcus_prefixes'):
+          # FIXME make 'stats detail dump' metrics readable
+          for fr, to in TYPES_CONV.iteritems():
+            if props[0] == fr: props[0] = to
+        
+        result[typename][props[0]] = { 'type' : props[1].lower(), 'min' : props[2], 'max' : props[3] }
+        result[typename]['dsnames'].append(props[0])
+        
+  return result
+
+#def get_latency_ms(sock, operation):
+#  begin = time.time()
+#  sock.sendall(operation)
+#  return (time.time() - begin) * 1000
+
+def get_latency_ms(sock, file, qos_key):
+  begin = time.time()
+  sock.sendall(QOS_OPS[qos_key])
+
+  while (1):
+    line = file.readline()
+    if not line or QOS_RES[qos_key] == line or 'NOT_FOUND\r\n' == line:
+      break
+
+  return (time.time() - begin) * 1000
+
+def fetch_stat(host, port):
+  result_stats = {}
+  result_stats_detail = {}
+
+  try:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(0.3)
+    s.connect((host, port))
+  except:
+    collectd.error('memcached_stat plugin: error connecting to %s:%d'%(MEMCACHED_HOST, port))
+    return None
+
+  fp = s.makefile('r')
+
+  try:
+    # stats
+    s.sendall('stats\r\n')
+
+    while (1):
+      line = fp.readline()
+      if not line or 'END\r\n' == line:
+        break
+      stat = line.replace('\r\n', '').split(' ')
+      result_stats[stat[1]] = stat[2]
+
+    # stats slabs
+    s.sendall('stats slabs\r\n')
+
+    while (1):
+      line = fp.readline()
+      if not line or 'END\r\n' == line:
+        break
+      stat = line.replace('\r\n', '').split(' ')
+      result_stats[stat[1]] = stat[2]
+
+    # stats detail dump
+    s.sendall('stats detail dump\r\n')
+
+    while (1):
+      line = fp.readline()
+      if not line or 'END\r\n' == line:
+        break
+      stat = line.replace('\r\n', '').split(' ')
+      prefix_name = stat[1]
+      prefix_stats = stat[2:]
+      result_stats_detail[prefix_name] = {}
+
+      for i in range(0, len(prefix_stats), 2):
+        prefix_stat_name = prefix_stats[i]
+        result_stats_detail[prefix_name][prefix_stat_name] = prefix_stats[i+1]
+
+    # QoS (get operation latencies)
+    result_stats['qos_kv_set']     = get_latency_ms(s, fp, 'qos_kv_set')
+    result_stats['qos_kv_get']     = get_latency_ms(s, fp, 'qos_kv_get')
+    result_stats['qos_lop_insert'] = get_latency_ms(s, fp, 'qos_lop_insert')
+    result_stats['qos_lop_get']    = get_latency_ms(s, fp, 'qos_lop_get')
+    result_stats['qos_lop_delete'] = get_latency_ms(s, fp, 'qos_lop_delete')
+    result_stats['qos_sop_insert'] = get_latency_ms(s, fp, 'qos_sop_insert')
+    result_stats['qos_sop_exist']  = get_latency_ms(s, fp, 'qos_sop_exist')
+    result_stats['qos_sop_delete'] = get_latency_ms(s, fp, 'qos_sop_delete')
+    result_stats['qos_bop_insert'] = get_latency_ms(s, fp, 'qos_bop_insert')
+    result_stats['qos_bop_get']    = get_latency_ms(s, fp, 'qos_bop_get')
+    result_stats['qos_bop_delete'] = get_latency_ms(s, fp, 'qos_bop_delete')
+
+  except socket.timeout:
+    collectd.error('memcached_stat plugin: socket timeout')
+    return result_stats, result_stats_detail
+
+  s.close()
+
+  return result_stats, result_stats_detail
+
+def config_callback(conf):
+  global MEMCACHED_HOST, TYPES_DB, MEMCACHED_PORTS, COLLECTION_MODE
+  for node in conf.children:
+    if node.key == 'Host':
+      MEMCACHED_HOST = node.values[0]
+    elif node.key == 'Port':
+      if node.values[0] == 'DETECT':
+        MEMCACHED_PORTS = get_memcached_ports()
+      else:
+        MEMCACHED_PORTS.append(str_to_num(node.values[0]))
+    elif node.key == 'TypesDB':
+      TYPES_DB = get_type_instances(node.values[0])
+    elif node.key == 'Mode':
+      COLLECTION_MODE = node.values[0]
+    else:
+      collectd.warning('arcus_stat plugin: Unknown config key: %s'%node.key)
+
+def read_callback():
+  global MEMCACHED_HOST, TYPES_DB, MEMCACHED_PORTS, COLLECTION_MODE
+  # FIXME always check available arcus ports
+  MEMCACHED_PORTS = get_memcached_ports()
+  for port in MEMCACHED_PORTS:
+    try:
+      stats, stats_detail = fetch_stat(MEMCACHED_HOST, port)
+
+      if COLLECTION_MODE == 'stat':
+        # stats
+        for type, entries in TYPES_DB.iteritems():
+          if not type.startswith('arcus_stats'): continue
+          varray = []
+          stat_failed = False
+          for dsname in entries['dsnames']:
+            if stats.has_key(dsname):
+              varray.append(str_to_num(stats[dsname]))
+            else:
+              collectd.warning('memcached_stat plugin: stats dont\'t have %s'%dsname)
+              stat_failed = True
+              break
+          if stat_failed: continue
+          value = collectd.Values(plugin='arcus_stat-%d'%port)
+          value.type = type
+          value.values = varray
+          value.dispatch()
+      elif COLLECTION_MODE == 'prefix':
+        # stats detail dump
+        for prefix, props in stats_detail.iteritems():
+          # TODO refine prefix
+          for type, entries in TYPES_DB.iteritems():
+            if not type.startswith('arcus_prefixes'): continue
+            if type.startswith('arcus_prefixes_meta'): continue
+            varray = []
+            stat_failed = False
+            for dsname in entries['dsnames']:
+              if props.has_key(dsname):
+                varray.append(str_to_num(props[dsname]))
+              else:
+                collectd.warning('memcached_stat plugin: prefix dont\'t have %s' % dsname)
+                stat_failed = True
+                break
+            if stat_failed: continue
+            value = collectd.Values(plugin='arcus_prefix-%d'%port)
+            value.type_instance = prefix
+            value.type = type
+            value.values = varray
+            value.dispatch()
+        # number of prefixes 
+        nprefixes = len(stats_detail)
+        value = collectd.Values(plugin='arcus_prefix-%d'%port)
+        value.type_instance = 'arcus_prefixes_meta'
+        value.type = 'arcus_prefixes_meta'
+        value.values = [nprefixes]
+        value.dispatch()
+      else:
+        collectd.warning('invalid mode : '%COLLECTION_MODE)
+
+    except Exception, e:
+      #collectd.warning('arcus_stat plugin: %s : type=%s, entries=%s'%(e, type, entries))
+      collectd.error('arcus_stat plugin: %s'%(traceback.format_exc()))
+
+
+if __name__ == '__main__':
+  read_callback()
+
+collectd.register_config(config_callback)
+collectd.register_read(read_callback)
+

--- a/docker/client-collectd.conf.d/collectd-arcus-prefix.conf
+++ b/docker/client-collectd.conf.d/collectd-arcus-prefix.conf
@@ -1,0 +1,33 @@
+FQDNLookup   true
+Interval     60
+
+LoadPlugin logfile
+
+<Plugin logfile>
+  LogLevel err
+  #File "/var/log/collectd/collectd-arcus-prefix.log"
+  File stderr
+  Timestamp true
+</Plugin>
+
+LoadPlugin network
+
+<Plugin network>
+  Server "${COLLECTD_LISTENER_IP}" "${COLLECTD_LISTENER_1M_PORT}"
+</Plugin>
+
+LoadPlugin python
+
+<Plugin python>
+  ModulePath "/usr/lib/collectd/python"
+  Import "arcus_stat"
+  LogTraces true
+
+  <Module arcus_stat>
+    Host "127.0.0.1"
+    Port "DETECT"
+    Mode "prefix"
+    TypesDB "/usr/share/collectd/types.db"
+  </Module>
+</Plugin>
+

--- a/docker/client-collectd.conf.d/collectd-arcus.conf
+++ b/docker/client-collectd.conf.d/collectd-arcus.conf
@@ -1,0 +1,89 @@
+FQDNLookup   true
+Interval     5
+
+LoadPlugin logfile
+
+<Plugin logfile>
+  LogLevel err
+  #File "/var/log/collectd/collectd-arcus.log"
+  File stderr
+  Timestamp true
+</Plugin>
+
+LoadPlugin network
+
+<Plugin network>
+  Server "${COLLECTD_LISTENER_IP}" "${COLLECTD_LISTENER_5S_PORT}"
+</Plugin>
+
+LoadPlugin cpu
+
+LoadPlugin interface
+
+LoadPlugin load
+
+LoadPlugin memory
+
+LoadPlugin processes
+
+LoadPlugin swap
+
+LoadPlugin vmem
+
+LoadPlugin protocols
+
+<Plugin protocols>
+  Value "TcpExt:TCPAbortOnLinger"
+  Value "TcpExt:TCPFastRetrans"
+  Value "TcpExt:DelayedACKLost"
+  Value "TcpExt:TW"
+  Value "TcpExt:TCPLoss"
+  Value "TcpExt:TCPAbortOnData"
+  Value "TcpExt:TCPAbortOnClose"
+  Value "TcpExt:TWKilled"
+  Value "TcpExt:TCPAbortOnTimeout"
+  Value "TcpExt:TCPPrequeueDropped"
+  Value "TcpExt:TCPLossFailures"
+  Value "TcpExt:TCPMemoryPressures"
+  Value "TcpExt:TWRecycled"
+  Value "TcpExt:TCPSlowStartRetrans"
+  Value "TcpExt:TCPLostRetransmit"
+  Value "TcpExt:TCPAbortOnMemory"
+  Value "TcpExt:TCPTimeouts"
+  Value "TcpExt:TCPAbortOnSyn"
+  Value "TcpExt:ListenDrops"
+  Value "TcpExt:TCPAbortFailed"
+  Value "TcpExt:TCPForwardRetrans"
+  Value "TcpExt:TCPLossUndo"
+  Value "TcpExt:ListenOverflows"
+  Value "Udp:InDatagrams"
+  Value "Udp:InErrors"
+  Value "Udp:NoPorts"
+  Value "Udp:OutDatagrams"
+  Value "/^Tcp:.*/"
+  IgnoreSelected false
+</Plugin>
+
+LoadPlugin disk
+
+<Plugin disk>
+  Disk "/^[hs]d[a-f][0-9]?$/"
+#  Disk "/^[dev/cciss/c0d0p].*/"
+  IgnoreSelected false
+</Plugin>
+
+LoadPlugin python
+
+<Plugin python>
+  ModulePath "/usr/lib/collectd/python"
+  Import "arcus_stat"
+  LogTraces true
+
+  <Module arcus_stat>
+    Host "127.0.0.1"
+    Port "DETECT"
+    Mode "stat"
+    TypesDB "/usr/share/collectd/types.db"
+  </Module>
+</Plugin>
+

--- a/docker/client-entrypoint.sh
+++ b/docker/client-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -e
+
+if [ -z "$COLLECTD_LISTENER_IP" ]; then
+    echo "COLLECTD_LISTENER_IP must be set."
+    exit 1
+fi
+
+sed -i "s/\${COLLECTD_LISTENER_IP}/$COLLECTD_LISTENER_IP/g" /etc/collectd/collectd.conf.d/collectd-arcus.conf
+sed -i "s/\${COLLECTD_LISTENER_5S_PORT}/$COLLECTD_LISTENER_5S_PORT/g" /etc/collectd/collectd.conf.d/collectd-arcus.conf
+
+sed -i "s/\${COLLECTD_LISTENER_IP}/$COLLECTD_LISTENER_IP/g" /etc/collectd/collectd.conf.d/collectd-arcus-prefix.conf
+sed -i "s/\${COLLECTD_LISTENER_1M_PORT}/$COLLECTD_LISTENER_1M_PORT/g" /etc/collectd/collectd.conf.d/collectd-arcus-prefix.conf
+
+collectd -C /etc/collectd/collectd.conf.d/collectd-arcus.conf
+collectd -C /etc/collectd/collectd.conf.d/collectd-arcus-prefix.conf
+
+exec "$@"

--- a/docker/collectd.conf
+++ b/docker/collectd.conf
@@ -1,0 +1,4 @@
+<Include "/etc/collectd/collectd.conf.d">
+  Filter "*.conf"
+</Include>
+

--- a/docker/server-collectd.conf.d/collectd-listener-1m.conf
+++ b/docker/server-collectd.conf.d/collectd-listener-1m.conf
@@ -1,0 +1,27 @@
+FQDNLookup   true
+Interval     60
+
+LoadPlugin logfile
+
+<Plugin logfile>
+  LogLevel info
+  File stderr
+  Timestamp true
+</Plugin>
+
+LoadPlugin network
+
+<Plugin network>
+  Listen "0.0.0.0" "25829"
+</Plugin>
+
+LoadPlugin rrdtool
+
+<Plugin rrdtool>
+  DataDir "/var/lib/collectd/rrd"
+  CacheTimeout 30
+  RandomTimeout 10
+  CacheFlush 300
+  WritesPerSecond 100
+  RRARows 200
+</Plugin>

--- a/docker/server-collectd.conf.d/collectd-listener-5s.conf
+++ b/docker/server-collectd.conf.d/collectd-listener-5s.conf
@@ -1,0 +1,84 @@
+FQDNLookup   true
+Interval     5
+
+LoadPlugin logfile
+
+<Plugin logfile>
+  LogLevel info
+  File stderr
+  Timestamp true
+</Plugin>
+
+LoadPlugin network
+
+<Plugin network>
+  Listen "0.0.0.0" "25828"
+</Plugin>
+
+LoadPlugin rrdtool
+
+<Plugin rrdtool>
+  DataDir "/var/lib/collectd/rrd"
+  CacheTimeout 30
+  RandomTimeout 10
+  CacheFlush 300
+  WritesPerSecond 100
+  RRARows 2400
+</Plugin>
+
+LoadPlugin cpu
+
+LoadPlugin interface
+
+LoadPlugin load
+
+LoadPlugin memory
+
+LoadPlugin processes
+
+LoadPlugin swap
+
+LoadPlugin vmem
+
+LoadPlugin protocols
+
+<Plugin protocols>
+  Value "TcpExt:TCPAbortOnLinger"
+  Value "TcpExt:TCPFastRetrans"
+  Value "TcpExt:DelayedACKLost"
+  Value "TcpExt:TW"
+  Value "TcpExt:TCPLoss"
+  Value "TcpExt:TCPAbortOnData"
+  Value "TcpExt:TCPAbortOnClose"
+  Value "TcpExt:TWKilled"
+  Value "TcpExt:TCPAbortOnTimeout"
+  Value "TcpExt:TCPPrequeueDropped"
+  Value "TcpExt:TCPLossFailures"
+  Value "TcpExt:TCPMemoryPressures"
+  Value "TcpExt:TWRecycled"
+  Value "TcpExt:TCPSlowStartRetrans"
+  Value "TcpExt:TCPLostRetransmit"
+  Value "TcpExt:TCPAbortOnMemory"
+  Value "TcpExt:TCPTimeouts"
+  Value "TcpExt:TCPAbortOnSyn"
+  Value "TcpExt:ListenDrops"
+  Value "TcpExt:TCPAbortFailed"
+  Value "TcpExt:TCPForwardRetrans"
+  Value "TcpExt:TCPLossUndo"
+  Value "TcpExt:ListenOverflows"
+  Value "Udp:InDatagrams"
+  Value "Udp:InErrors"
+  Value "Udp:NoPorts"
+  Value "Udp:OutDatagrams"
+  Value "/^Tcp:.*/"
+  IgnoreSelected false
+</Plugin>
+
+LoadPlugin disk
+
+<Plugin disk>
+  Disk "/^[hs]d[a-f][0-9]?$/"
+#  Disk "/^[dev/cciss/c0d0p].*/"
+  IgnoreSelected false
+</Plugin>
+

--- a/docker/types.db
+++ b/docker/types.db
@@ -1,0 +1,234 @@
+absolute                value:ABSOLUTE:0:U
+apache_bytes            value:DERIVE:0:U
+apache_connections      value:GAUGE:0:65535
+apache_idle_workers     value:GAUGE:0:65535
+apache_requests         value:DERIVE:0:U
+apache_scoreboard       value:GAUGE:0:65535
+ath_nodes               value:GAUGE:0:65535
+ath_stat                value:DERIVE:0:U
+bitrate                 value:GAUGE:0:4294967295
+bytes                   value:GAUGE:0:U
+cache_eviction          value:DERIVE:0:U
+cache_operation         value:DERIVE:0:U
+cache_ratio             value:GAUGE:0:100
+cache_result            value:DERIVE:0:U
+cache_size              value:GAUGE:0:4294967295
+charge                  value:GAUGE:0:U
+compression_ratio       value:GAUGE:0:2
+compression             uncompressed:DERIVE:0:U, compressed:DERIVE:0:U
+connections             value:DERIVE:0:U
+conntrack               value:GAUGE:0:4294967295
+contextswitch           value:DERIVE:0:U
+counter                 value:COUNTER:U:U
+cpufreq                 value:GAUGE:0:U
+cpu                     value:DERIVE:0:U
+current_connections     value:GAUGE:0:U
+current_sessions        value:GAUGE:0:U
+current                 value:GAUGE:U:U
+delay                   value:GAUGE:-1000000:1000000
+derive                  value:DERIVE:0:U
+df_complex              value:GAUGE:0:U
+df_inodes               value:GAUGE:0:U
+df                      used:GAUGE:0:1125899906842623, free:GAUGE:0:1125899906842623
+disk_latency            read:GAUGE:0:U, write:GAUGE:0:U
+disk_merged             read:DERIVE:0:U, write:DERIVE:0:U
+disk_octets             read:DERIVE:0:U, write:DERIVE:0:U
+disk_ops_complex        value:DERIVE:0:U
+disk_ops                read:DERIVE:0:U, write:DERIVE:0:U
+disk_time               read:DERIVE:0:U, write:DERIVE:0:U
+dns_answer              value:DERIVE:0:U
+dns_notify              value:DERIVE:0:U
+dns_octets              queries:DERIVE:0:U, responses:DERIVE:0:U
+dns_opcode              value:DERIVE:0:U
+dns_qtype_cached        value:GAUGE:0:4294967295
+dns_qtype               value:DERIVE:0:U
+dns_query               value:DERIVE:0:U
+dns_question            value:DERIVE:0:U
+dns_rcode               value:DERIVE:0:U
+dns_reject              value:DERIVE:0:U
+dns_request             value:DERIVE:0:U
+dns_resolver            value:DERIVE:0:U
+dns_response            value:DERIVE:0:U
+dns_transfer            value:DERIVE:0:U
+dns_update              value:DERIVE:0:U
+dns_zops                value:DERIVE:0:U
+email_check             value:GAUGE:0:U
+email_count             value:GAUGE:0:U
+email_size              value:GAUGE:0:U
+entropy                 value:GAUGE:0:4294967295
+fanspeed                value:GAUGE:0:U
+file_size               value:GAUGE:0:U
+files                   value:GAUGE:0:U
+fork_rate               value:DERIVE:0:U
+frequency_offset        value:GAUGE:-1000000:1000000
+frequency               value:GAUGE:0:U
+fscache_stat            value:DERIVE:0:U
+gauge                   value:GAUGE:U:U
+hash_collisions         value:DERIVE:0:U
+http_request_methods    value:DERIVE:0:U
+http_requests           value:DERIVE:0:U
+http_response_codes     value:DERIVE:0:U
+humidity                value:GAUGE:0:100
+if_collisions           value:DERIVE:0:U
+if_dropped              rx:DERIVE:0:U, tx:DERIVE:0:U
+if_errors               rx:DERIVE:0:U, tx:DERIVE:0:U
+if_multicast            value:DERIVE:0:U
+if_octets               rx:DERIVE:0:U, tx:DERIVE:0:U
+if_packets              rx:DERIVE:0:U, tx:DERIVE:0:U
+if_rx_errors            value:DERIVE:0:U
+if_tx_errors            value:DERIVE:0:U
+invocations             value:DERIVE:0:U
+io_octets               rx:DERIVE:0:U, tx:DERIVE:0:U
+io_packets              rx:DERIVE:0:U, tx:DERIVE:0:U
+ipt_bytes               value:DERIVE:0:U
+ipt_packets             value:DERIVE:0:U
+irq                     value:DERIVE:0:U
+latency                 value:GAUGE:0:65535
+links                   value:GAUGE:0:U
+load                    shortterm:GAUGE:0:100, midterm:GAUGE:0:100, longterm:GAUGE:0:100
+md_disks                value:GAUGE:0:U
+memcached_command       value:DERIVE:0:U
+memcached_connections   value:GAUGE:0:U
+memcached_items         value:GAUGE:0:U
+memcached_octets        rx:DERIVE:0:U, tx:DERIVE:0:U
+memcached_ops           value:DERIVE:0:U
+memory                  value:GAUGE:0:281474976710656
+multimeter              value:GAUGE:U:U
+mutex_operations        value:DERIVE:0:U
+mysql_commands          value:DERIVE:0:U
+mysql_handler           value:DERIVE:0:U
+mysql_locks             value:DERIVE:0:U
+mysql_log_position      value:DERIVE:0:U
+mysql_octets            rx:DERIVE:0:U, tx:DERIVE:0:U
+nfs_procedure           value:DERIVE:0:U
+nginx_connections       value:GAUGE:0:U
+nginx_requests          value:DERIVE:0:U
+node_octets             rx:DERIVE:0:U, tx:DERIVE:0:U
+node_rssi               value:GAUGE:0:255
+node_stat               value:DERIVE:0:U
+node_tx_rate            value:GAUGE:0:127
+operations              value:DERIVE:0:U
+percent                 value:GAUGE:0:100.1
+pf_counters             value:DERIVE:0:U
+pf_limits               value:DERIVE:0:U
+pf_source               value:DERIVE:0:U
+pf_states               value:GAUGE:0:U
+pf_state                value:DERIVE:0:U
+pg_blks                 value:DERIVE:0:U
+pg_db_size              value:GAUGE:0:U
+pg_n_tup_c              value:DERIVE:0:U
+pg_n_tup_g              value:GAUGE:0:U
+pg_numbackends          value:GAUGE:0:U
+pg_scan                 value:DERIVE:0:U
+pg_xact                 value:DERIVE:0:U
+ping_droprate           value:GAUGE:0:100
+ping_stddev             value:GAUGE:0:65535
+ping                    value:GAUGE:0:65535
+players                 value:GAUGE:0:1000000
+power                   value:GAUGE:0:U
+protocol_counter        value:DERIVE:0:U
+ps_code                 value:GAUGE:0:9223372036854775807
+ps_count                processes:GAUGE:0:1000000, threads:GAUGE:0:1000000
+ps_cputime              user:DERIVE:0:U, syst:DERIVE:0:U
+ps_data                 value:GAUGE:0:9223372036854775807
+ps_disk_octets          read:DERIVE:0:U, write:DERIVE:0:U
+ps_disk_ops             read:DERIVE:0:U, write:DERIVE:0:U
+ps_pagefaults           minflt:DERIVE:0:U, majflt:DERIVE:0:U
+ps_rss                  value:GAUGE:0:9223372036854775807
+ps_stacksize            value:GAUGE:0:9223372036854775807
+ps_state                value:GAUGE:0:65535
+ps_vm                   value:GAUGE:0:9223372036854775807
+queue_length            value:GAUGE:0:U
+records                 value:GAUGE:0:U
+requests                value:GAUGE:0:U
+response_time           value:GAUGE:0:U
+route_etx               value:GAUGE:0:U
+route_metric            value:GAUGE:0:U
+routes                  value:GAUGE:0:U
+serial_octets           rx:DERIVE:0:U, tx:DERIVE:0:U
+signal_noise            value:GAUGE:U:0
+signal_power            value:GAUGE:U:0
+signal_quality          value:GAUGE:0:U
+snr                     value:GAUGE:0:U
+spam_check              value:GAUGE:0:U
+spam_score              value:GAUGE:U:U
+swap_io                 value:DERIVE:0:U
+swap                    value:GAUGE:0:1099511627776
+tcp_connections         value:GAUGE:0:4294967295
+temperature             value:GAUGE:-273.15:U
+threads                 value:GAUGE:0:U
+time_dispersion         value:GAUGE:-1000000:1000000
+timeleft                value:GAUGE:0:3600
+time_offset             value:GAUGE:-1000000:1000000
+total_bytes             value:DERIVE:0:U
+total_connections       value:DERIVE:0:U
+total_operations        value:DERIVE:0:U
+total_requests          value:DERIVE:0:U
+total_sessions          value:DERIVE:0:U
+total_threads           value:DERIVE:0:U
+total_time_in_ms        value:DERIVE:0:U
+total_values            value:DERIVE:0:U
+uptime                  value:GAUGE:0:4294967295
+users                   value:GAUGE:0:65535
+vcpu                    value:GAUGE:0:U
+virt_cpu_total          value:DERIVE:0:U
+virt_vcpu               value:DERIVE:0:U
+vmpage_action           value:DERIVE:0:U
+vmpage_faults           minflt:DERIVE:0:U, majflt:DERIVE:0:U
+vmpage_io               in:DERIVE:0:U, out:DERIVE:0:U
+vmpage_number           value:GAUGE:0:4294967295
+volatile_changes        value:GAUGE:0:U
+voltage_threshold       value:GAUGE:U:U, threshold:GAUGE:U:U
+voltage                 value:GAUGE:U:U
+vs_memory               value:GAUGE:0:9223372036854775807
+vs_processes            value:GAUGE:0:65535
+vs_threads              value:GAUGE:0:65535
+#
+# Legacy types
+# (required for the v5 upgrade target)
+#
+arc_counts              demand_data:COUNTER:0:U, demand_metadata:COUNTER:0:U, prefetch_data:COUNTER:0:U, prefetch_metadata:COUNTER:0:U
+arc_l2_bytes            read:COUNTER:0:U, write:COUNTER:0:U
+arc_l2_size             value:GAUGE:0:U
+arc_ratio               value:GAUGE:0:U
+arc_size                current:GAUGE:0:U, target:GAUGE:0:U, minlimit:GAUGE:0:U, maxlimit:GAUGE:0:U
+mysql_qcache            hits:COUNTER:0:U, inserts:COUNTER:0:U, not_cached:COUNTER:0:U, lowmem_prunes:COUNTER:0:U, queries_in_cache:GAUGE:0:U
+mysql_threads           running:GAUGE:0:U, connected:GAUGE:0:U, cached:GAUGE:0:U, created:COUNTER:0:U
+
+# Arcus-memcached STATS
+
+arcus_stats_process   threads:GAUGE:0:1000000, curr_connections:GAUGE:0:U
+
+arcus_stats_cpu       rusage_user:DERIVE:0:U, rusage_system:DERIVE:0:U
+
+arcus_stats_network   bytes_read:DERIVE:0:U, bytes_written:DERIVE:0:U
+
+arcus_stats_memory    curr_items:GAUGE:0:U, bytes:GAUGE:0:U, total_malloced:GAUGE:0:U, engine_maxbytes:GAUGE:0:U, sticky_items:GAUGE:0:U, sticky_bytes:GAUGE:0:U, sticky_limit:GAUGE:0:U
+
+arcus_stats_item      evictions:DERIVE:0:U, reclaimed:DERIVE:0:U
+
+arcus_stats_qos       qos_kv_set:GAUGE:0:U, qos_kv_get:GAUGE:0:U, qos_lop_ins:GAUGE:0:U, qos_lop_get:GAUGE:0:U, qos_lop_del:GAUGE:0:U, qos_sop_ins:GAUGE:0:U, qos_sop_exist:GAUGE:0:U, qos_sop_del:GAUGE:0:U, qos_bop_ins:GAUGE:0:U, qos_bop_get:GAUGE:0:U, qos_bop_del:GAUGE:0:U
+
+arcus_stats_attr      cmd_getattr:DERIVE:0:U, cmd_setattr:DERIVE:0:U, getattr_hits:DERIVE:0:U, getattr_misses:DERIVE:0:U, setattr_hits:DERIVE:0:U, setattr_misses:DERIVE:0:U
+
+arcus_stats_kv        cmd_get:DERIVE:0:U, cmd_set:DERIVE:0:U, cmd_flush:DERIVE:0:U, cmd_flush_prefix:DERIVE:0:U, get_hits:DERIVE:0:U, get_misses:DERIVE:0:U, incr_misses:DERIVE:0:U, incr_hits:DERIVE:0:U, decr_misses:DERIVE:0:U, decr_hits:DERIVE:0:U, delete_hits:DERIVE:0:U, delete_misses:DERIVE:0:U, cas_hits:DERIVE:0:U, cas_misses:DERIVE:0:U
+
+arcus_stats_list      cmd_lop_create:DERIVE:0:U, cmd_lop_ins:DERIVE:0:U, cmd_lop_del:DERIVE:0:U, cmd_lop_get:DERIVE:0:U, lop_create_oks:DERIVE:0:U, lop_ins_hits:DERIVE:0:U, lop_ins_misses:DERIVE:0:U, lop_del_elem_hits:DERIVE:0:U, lop_del_none_hits:DERIVE:0:U, lop_del_misses:DERIVE:0:U, lop_get_elem_hits:DERIVE:0:U, lop_get_none_hits:DERIVE:0:U, lop_get_misses:DERIVE:0:U
+
+arcus_stats_set       cmd_sop_create:DERIVE:0:U, cmd_sop_ins:DERIVE:0:U, cmd_sop_del:DERIVE:0:U, cmd_sop_get:DERIVE:0:U, cmd_sop_exist:DERIVE:0:U, sop_create_oks:DERIVE:0:U, sop_ins_hits:DERIVE:0:U, sop_ins_misses:DERIVE:0:U, sop_del_elem_hits:DERIVE:0:U, sop_del_none_hits:DERIVE:0:U, sop_del_misses:DERIVE:0:U, sop_get_elem_hits:DERIVE:0:U, sop_get_none_hits:DERIVE:0:U, sop_get_misses:DERIVE:0:U, sop_exist_hits:DERIVE:0:U, sop_exist_misses:DERIVE:0:U
+
+arcus_stats_btree     cmd_bop_create:DERIVE:0:U, cmd_bop_ins:DERIVE:0:U, cmd_bop_upd:DERIVE:0:U, cmd_bop_del:DERIVE:0:U, cmd_bop_get:DERIVE:0:U, cmd_bop_count:DERIVE:0:U, cmd_bop_mget:DERIVE:0:U, cmd_bop_smget:DERIVE:0:U, cmd_bop_incr:DERIVE:0:U, cmd_bop_decr:DERIVE:0:U, bop_create_oks:DERIVE:0:U, bop_ins_hits:DERIVE:0:U, bop_ins_misses:DERIVE:0:U, bop_upd_elem_hits:DERIVE:0:U, bop_upd_none_hits:DERIVE:0:U, bop_upd_misses:DERIVE:0:U, bop_del_elem_hits:DERIVE:0:U, bop_del_none_hits:DERIVE:0:U, bop_del_misses:DERIVE:0:U, bop_get_elem_hits:DERIVE:0:U, bop_get_none_hits:DERIVE:0:U, bop_get_misses:DERIVE:0:U, bop_count_hits:DERIVE:0:U, bop_count_misses:DERIVE:0:U, bop_mget_oks:DERIVE:0:U, bop_smget_oks:DERIVE:0:U, bop_incr_elem_hits:DERIVE:0:U, bop_incr_none_hits:DERIVE:0:U, bop_incr_misses:DERIVE:0:U, bop_decr_elem_hits:DERIVE:0:U, bop_decr_none_hits:DERIVE:0:U, bop_decr_misses:DERIVE:0:U
+
+# Arcus-memcached STATS DETAIL DUMP
+
+arcus_prefixes_kv     kv_get:DERIVE:0:U, kv_hit:DERIVE:0:U, kv_set:DERIVE:0:U, kv_del:DERIVE:0:U
+
+arcus_prefixes_list   lop_create:DERIVE:0:U, lop_insert:DERIVE:0:U, lop_insert_hit:DERIVE:0:U, lop_delete:DERIVE:0:U, lop_delete_hit:DERIVE:0:U, lop_get:DERIVE:0:U, lop_get_hit:DERIVE:0:U
+
+arcus_prefixes_set    sop_create:DERIVE:0:U, sop_insert:DERIVE:0:U, sop_insert_hit:DERIVE:0:U, sop_delete:DERIVE:0:U, sop_delete_hit:DERIVE:0:U, sop_get:DERIVE:0:U, sop_get_hit:DERIVE:0:U, sop_exist:DERIVE:0:U, sop_exist_hit:DERIVE:0:U
+
+arcus_prefixes_btree  bop_create:DERIVE:0:U, bop_insert:DERIVE:0:U, bop_insert_hit:DERIVE:0:U, bop_update:DERIVE:0:U, bop_update_hit:DERIVE:0:U, bop_incr:DERIVE:0:U, bop_incr_hit:DERIVE:0:U, bop_decr:DERIVE:0:U, bop_decr_hit:DERIVE:0:U, bop_delete:DERIVE:0:U, bop_delete_hit:DERIVE:0:U, bop_get:DERIVE:0:U, bop_get_hit:DERIVE:0:U, bop_count:DERIVE:0:U, bop_count_hit:DERIVE:0:U
+
+arcus_prefixes_attr   getattr:DERIVE:0:U, setattr:DERIVE:0:U
+
+arcus_prefixes_meta   nprefixes:GAUGE:0:U


### PR DESCRIPTION
Related PR : https://github.com/naver/arcus-memcached/pull/48

Dockerized collectd server and arcus-memcached client with collectd support. collectd server has no dependencies, but collectd client based on arcus-memcached docker image (on review) and it needs the COLLECTD_LISTENER_IP which is the collectd server ip.

The collected rrd data are stored on `/var/lib/collectd/rrd` in the container, and later, the directory can be mounted by using `volumes_from` directive.

Usage:

``` bash
# Build
$ cd docker
$ docker build -t arcus/arcus-collectd-server -f Dockerfile.server .
$ docker build -t arcus/arcus-memcached-collectd -f Dockerfile.client .

# Run
$ docker run --name collectd-server --rm arcus/arcus-collectd-server
$ docker run --name collectd-client --rm -e COLLECTD_LISTENER_IP=172.17.0.2 arcus/arcus-memcached-collectd
```
